### PR TITLE
Rename UseExpression to Activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To use the library:
 
 ## Parts of an Equation
 
-* **UseExpression** - A string expression that must evaluate to a true or false. If this UseExpression evaluates to true, then the equation and the inner equations are executed.
+* **Activation** - A string expression that must evaluate to a true or false. If this Activation expression evaluates to true, then the equation and the inner equations are executed.
 
 * **Expression** - A string that produces a value (number, boolean, or text). The value is then assigned to the variable named in Target.
 
@@ -51,7 +51,7 @@ EquationProject project = new EquationProject()
     {
         new Equation()
         {
-            UseExpression = "true",
+            Activation = "true",
             Expression = "2 * 1",
             Target = "T1"
         }


### PR DESCRIPTION
## Changes

This PR renames the `UseExpression` property to `Activation` throughout the codebase for better clarity and more intuitive naming.

## Details

- Renamed the `UseExpression` property to `Activation` in the DTO class
- Renamed the `useExpressionField` field to `activationField`
- Updated all references in the codebase including:
  - EquationSolver.cs
  - EquationSolverFactory.cs
  - Equation_arranging.cs
  - All unit test files
- Updated README.md to reflect the property name change

## Testing

No functional changes were made, only renaming. The existing tests should continue to pass with the new property name.