### PR TITLE
Update PlantUML diagrams: rename UseExpression to Activation

### DIFF
--- a/plantuml/README.md
+++ b/plantuml/README.md
@@ -18,6 +18,10 @@ This directory contains PlantUML diagrams that document the EquationSolver proje
 
 7. **Object Diagram** (`object_diagram.puml`): Provides an example of an equation project for solving a quadratic equation.
 
+8. **Package Diagram** (`package_diagram.puml`): Shows the organization of packages in the system.
+
+9. **Entity-Relationship Diagram** (`entity_relationship_diagram.puml`): Focuses on the data model aspects of the system.
+
 ## How to View These Diagrams
 
 You can view these PlantUML diagrams using:
@@ -56,3 +60,9 @@ The state diagram shows the different states an equation can be in during its li
 
 ### Object Diagram
 The object diagram provides a concrete example of an equation project for solving a quadratic equation. It shows the objects and their relationships in a specific scenario.
+
+### Package Diagram
+The package diagram shows the organization of packages in the system, illustrating how the code is structured into logical groups and the dependencies between these groups.
+
+### Entity-Relationship Diagram
+The entity-relationship diagram focuses on the data model aspects of the system, showing the main entities (like EquationProject, Equation, Variable, etc.) and their relationships.

--- a/plantuml/activity_diagram.puml
+++ b/plantuml/activity_diagram.puml
@@ -27,9 +27,9 @@ partition "Equation Solving Process" {
     :Get Next Equation;
     
     repeat
-      :Evaluate UseExpression;
+      :Evaluate Activation;
       
-      if (UseExpression == true?) then (yes)
+      if (Activation == true?) then (yes)
         :Evaluate Expression;
         
         :Check if Target is Table Reference;

--- a/plantuml/class_diagram.puml
+++ b/plantuml/class_diagram.puml
@@ -92,7 +92,7 @@ package "EquationSolver" {
     class Equation {
       + string Name
       + string Trigger
-      + string UseExpression
+      + string Activation
       + string Expression
       + int Iterate
       + string Target

--- a/plantuml/entity_relationship_diagram.puml
+++ b/plantuml/entity_relationship_diagram.puml
@@ -1,0 +1,85 @@
+@startuml EquationSolver Entity Relationship Diagram
+
+skinparam entityBackgroundColor LightBlue
+skinparam entityBorderColor DarkBlue
+skinparam linetype ortho
+
+entity "EquationProject" as project {
+  * Title : string
+  --
+  * Settings : SolverSettings
+  * Audit : AuditInfo
+}
+
+entity "SolverSettings" as settings {
+  * CalculationMethod : CalculationMethods
+}
+
+entity "AuditInfo" as audit {
+  * Created : DateTime
+  * Modified : DateTime
+  * Author : string
+  * Version : string
+}
+
+entity "Equation" as equation {
+  * Name : string
+  * Expression : string
+  * Target : string
+  --
+  * Activation : string
+  * Trigger : string
+  * Iterate : int
+}
+
+entity "Function" as function {
+  * Name : string
+  * Expression : string
+  --
+  * Description : string
+}
+
+entity "Argument" as argument {
+  * Name : string
+  * Ordinal : int
+  --
+  * Default : string
+}
+
+entity "Variable" as variable {
+  * Name : string
+  * StringValue : string
+  --
+  * DecimalValue : decimal
+  * DoubleValue : double
+  * BoolValue : bool
+}
+
+entity "Table" as table {
+  * Name : string
+}
+
+entity "Row" as row {
+  * Label : string
+}
+
+entity "Column" as column {
+  * Value : string
+}
+
+project ||--o{ equation : contains
+project ||--o{ function : contains
+project ||--o{ variable : contains
+project ||--o{ table : contains
+project ||--|| settings : has
+project ||--|| audit : has
+
+function ||--o{ argument : has
+
+equation }o--o{ equation : nested equations
+
+table ||--|| row : header
+table ||--o{ row : data rows
+row ||--o{ column : contains
+
+@enduml

--- a/plantuml/object_diagram.puml
+++ b/plantuml/object_diagram.puml
@@ -27,7 +27,7 @@ package "Example Equation Project" {
   
   object "eq_discriminant : Equation" as eq_discriminant {
     Name = "Calculate Discriminant"
-    UseExpression = "true"
+    Activation = "true"
     Expression = "b^2 - 4*a*c"
     Target = "discriminant"
     Iterate = 1
@@ -35,7 +35,7 @@ package "Example Equation Project" {
   
   object "eq_solution1 : Equation" as eq_solution1 {
     Name = "Solution 1"
-    UseExpression = "discriminant >= 0"
+    Activation = "discriminant >= 0"
     Expression = "(-b + sqrt(discriminant))/(2*a)"
     Target = "x1"
     Iterate = 1
@@ -43,7 +43,7 @@ package "Example Equation Project" {
   
   object "eq_solution2 : Equation" as eq_solution2 {
     Name = "Solution 2"
-    UseExpression = "discriminant >= 0"
+    Activation = "discriminant >= 0"
     Expression = "(-b - sqrt(discriminant))/(2*a)"
     Target = "x2"
     Iterate = 1
@@ -51,7 +51,7 @@ package "Example Equation Project" {
   
   object "eq_no_solution : Equation" as eq_no_solution {
     Name = "No Real Solutions"
-    UseExpression = "discriminant < 0"
+    Activation = "discriminant < 0"
     Expression = "\"No real solutions\""
     Target = "result"
     Iterate = 1

--- a/plantuml/package_diagram.puml
+++ b/plantuml/package_diagram.puml
@@ -1,0 +1,68 @@
+@startuml EquationSolver Package Diagram
+
+skinparam packageStyle rectangle
+skinparam packageBackgroundColor LightBlue
+skinparam packageBorderColor DarkBlue
+
+package "EquationSolver" {
+  package "Core" {
+    [IEquationSolver]
+    [IExpressionSolver]
+    [IVariableProvider]
+    [EquationSolver]
+    [EquationSolverFactory]
+    [DecimalExpressionSolver]
+    [DoubleExpressionSolver]
+    [VariableProvider]
+    [VariableTable]
+    [VariableTableRow]
+    [EquationAlgebra]
+    [Utilities]
+  }
+  
+  package "Dto" {
+    [EquationProject]
+    [EquationProjectMerge]
+    [Equation]
+    [Function]
+    [Argument]
+    [Variable]
+    [Table]
+    [Row]
+    [SolverSettings]
+    [AuditInfo]
+  }
+  
+  package "Events" {
+    [ExceptionEventArgs]
+    [VariableNotFoundEventArgs]
+  }
+  
+  package "Enums" {
+    [ResultType]
+    [CalculationMethods]
+  }
+}
+
+package "EquationSolver.Unit.Tests" {
+  [SimpleMathExpressionTests]
+  [BranchingTests]
+  [FunctionsTests]
+  [LogicalTests]
+  [MultiStepTests]
+  [TrigonometryTests]
+  [UserDefinedFunctionTests]
+  [VariableTableTests]
+  [ErrorsTests]
+  [TriggerTests]
+  [StaticExpressionTests]
+  [Helpers]
+}
+
+"Core" ..> "Dto" : uses
+"Core" ..> "Events" : uses
+"Core" ..> "Enums" : uses
+"EquationSolver.Unit.Tests" ..> "Core" : tests
+"EquationSolver.Unit.Tests" ..> "Dto" : uses
+
+@enduml

--- a/plantuml/sequence_diagram.puml
+++ b/plantuml/sequence_diagram.puml
@@ -55,7 +55,7 @@ loop for each equation in Equations
         Solver -> Solver : ExecuteEquation(equation)
         activate Solver #DarkSalmon
         
-        Solver -> ExprSolver : Resolve(equation.UseExpression, VariableProvider)
+        Solver -> ExprSolver : Resolve(equation.Activation, VariableProvider)
         ExprSolver --> Solver : BoolResult
         
         alt BoolResult == true

--- a/plantuml/state_diagram.puml
+++ b/plantuml/state_diagram.puml
@@ -22,9 +22,9 @@ state Ready {
 }
 
 state Evaluating {
-  [*] --> UseExpressionEvaluated : Evaluate UseExpression
-  UseExpressionEvaluated --> Skipped : UseExpression == false
-  UseExpressionEvaluated --> ExpressionEvaluated : UseExpression == true
+  [*] --> ActivationEvaluated : Evaluate Activation
+  ActivationEvaluated --> Skipped : Activation == false
+  ActivationEvaluated --> ExpressionEvaluated : Activation == true
   ExpressionEvaluated --> TargetAssigned : Assign result to target
   TargetAssigned --> ChildrenProcessing : Process child equations
   ChildrenProcessing --> Completed : All children processed

--- a/plantuml/use_case_diagram.puml
+++ b/plantuml/use_case_diagram.puml
@@ -55,7 +55,7 @@ end note
 
 note right of UC7
   Equations are solved in order,
-  with branching based on UseExpression
+  with branching based on Activation
 end note
 
 note right of UC9


### PR DESCRIPTION
## Changes

- Updated all PlantUML diagrams to rename "UseExpression" to "Activation" for consistency
- Added two new PlantUML diagrams:
  - Package Diagram: Shows the organization of packages in the system
  - Entity-Relationship Diagram: Focuses on the data model aspects
- Updated README.md in the plantuml folder to include descriptions of the new diagrams

## Purpose

This PR updates the terminology in all PlantUML diagrams to be consistent with the codebase, changing "UseExpression" to "Activation". It also enhances the documentation by adding two new diagram types that provide additional perspectives on the system architecture.